### PR TITLE
feat: ability to add custom CSS via settings

### DIFF
--- a/main.js
+++ b/main.js
@@ -319,12 +319,21 @@ const defaultSettings = {
     ],
     "sidebar": false, "sidebarPosition": "right", "sidebarWidgets": [
     ],
-    "unsplashApiKey": "", 
+    "unsplashApiKey": "",
     "showUnsplashRefresh": false,
-    "unsplashUpdateFrequency": "daily"
+    "unsplashUpdateFrequency": "daily",
+    "customCSS": ""
 };
 
 const settings = JSON.parse(localStorage.getItem("settings")) || defaultSettings;
+
+// Apply custom CSS if provided
+if (settings.customCSS) {
+    const styleElement = document.createElement('style');
+    styleElement.id = 'user-custom-css';
+    styleElement.textContent = settings.customCSS;
+    document.head.appendChild(styleElement);
+}
 
 if (settings.useUnsplash) {
     setUnsplashBackground();

--- a/options.html
+++ b/options.html
@@ -173,6 +173,17 @@
                     <div class="setting-row"><label>Pixel Art Color (Dark Theme)<input type="color" id="pixelArtColorDark"></label></div>
                     <div class="setting-row"><label>Pixel Art Color (Light Theme)<input type="color" id="pixelArtColorLight"></label></div>
                 </div>
+
+                <div class="setting-row" style="margin-top: 2em;">
+                    <label for="custom-css">Custom CSS</label>
+                    <p style="font-size: 0.9em; opacity: 0.8; margin-top: 0.3em; margin-bottom: 0.8em;">Add your own CSS to customize the appearance of the new tab page. Changes apply after saving settings.</p>
+                    <textarea id="custom-css" rows="10" placeholder="/* Add your custom CSS here */
+/* Example:
+body { font-family: 'Comic Sans MS'; }
+.clock { font-size: 5em; }
+*/" style="width: 100%; font-family: monospace; font-size: 0.9em;"></textarea>
+                    <p style="font-size: 0.8em; opacity: 0.7; margin-top: 0.5em;">Note: Invalid CSS may affect page styling. Use the "Restore Defaults" button if something breaks.</p>
+                </div>
             </div>
 
             <div id="sidebar-settings" class="options-panel">

--- a/options.js
+++ b/options.js
@@ -23,11 +23,13 @@ const defaultSettings = {
     "pixelArtColorDark": "#cccccc",
     "pixelArtColorLight": "#b04288",
     "availableWidgets": ["calendar", "todo"]
-    , "useUnsplash": false, 
+    , "useUnsplash": false,
     "unsplashApiKey": "",
     "unsplashUpdateFrequency": "daily",
     "showUnsplashRefresh": false,
-    "backgroundImage": ""};
+    "backgroundImage": "",
+	"customCSS": ""
+};
 
 Object.assign(defaultSettings, {
     "sidebar": false, "sidebarPosition": "right", "sidebarWidgets": []
@@ -80,7 +82,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const settings_keys = [
         "clock", "weather", "useCustomCity", "customCity", "tempUnit", "bookmarks", "bookmarkFolder", "topRight", "topRightOrder", "pixelArt", "selectedPixelArt",
         "customSVG", "pixelArtOpacity", "pixelArtDensity", "pixelArtColorDark", "pixelArtColorLight", "availableWidgets", "theme", "backgroundImage",
-        "sidebar", "sidebarPosition", "sidebarWidgets", "useUnsplash", "unsplashApiKey", "unsplashUpdateFrequency", "showUnsplashRefresh"
+        "sidebar", "sidebarPosition", "sidebarWidgets", "useUnsplash", "unsplashApiKey", "unsplashUpdateFrequency", "showUnsplashRefresh", "customCSS"
     ];
 
     let settingsJsonStr = localStorage.getItem("settings") || JSON.stringify(defaultSettings);
@@ -146,6 +148,9 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     if (settings['pixelArtColorLight']) {
         document.getElementById("pixelArtColorLight").value = settings['pixelArtColorLight'];
+    }
+    if (settings['customCSS']) {
+        document.getElementById("custom-css").value = settings['customCSS'];
     }
     if (settings['sidebar']) {
         document.getElementById("show-sidebar").checked = true;
@@ -403,6 +408,11 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             else if (key === 'showUnsplashRefresh') {
                 settings_obj[key] = document.getElementById('show-unsplash-refresh').checked;
+            }
+            else if (key === 'customCSS') {
+                // Sanitize: remove </style> tags to prevent breaking out of style block
+                const rawCSS = document.getElementById('custom-css').value;
+                settings_obj[key] = rawCSS.replace(/<\/style>/gi, '');
             }
             else {
                 settings_obj[key] = document.getElementById("show-" + key).checked;


### PR DESCRIPTION
Allows users to apply their own custom CSS, to extend the default styles applied by the extension. 

The styles are stored on the `customCSS` property within the settings object. If the styles are detected, they are added into a new `user-custom-css` style tag which is appended to the `<head>`.

Screenshots:
<img width="3606" height="2330" alt="CleanShot 2025-11-03 at 21 42 14@2x" src="https://github.com/user-attachments/assets/56988470-a689-475c-80ee-4ab5649df34f" />
<img width="3606" height="2330" alt="CleanShot 2025-11-03 at 21 42 36@2x" src="https://github.com/user-attachments/assets/0c01950b-4bca-41bc-9e99-9d80ebbe8266" />
