### PR TITLE
User higher res image in about section

### DIFF
--- a/options.html
+++ b/options.html
@@ -228,7 +228,7 @@ body { font-family: 'Comic Sans MS'; }
             <div id="about" class="options-panel">
                 <h2>About</h2>
                 <div style="display:flex; align-items:center; gap:1rem; margin-bottom:1rem;">
-                    <img id="about-logo" src="favicons/favicon-128x128.png" alt="Logo" style="width:72px;height:72px;border-radius:12px;box-shadow:0 4px 8px rgba(0,0,0,0.12);">
+                    <img id="about-logo" src="favicons/android-chrome-512x512.png" alt="Logo" style="width:72px;height:72px;border-radius:12px;box-shadow:0 4px 8px rgba(0,0,0,0.12);">
                     <div>
                         <div id="about-title" role="button" tabindex="0" style="font-weight:bold; font-size:1.1rem;">Minimal New Tab</div>
                         <div style="opacity:0.8; margin-top:0.25rem;">Version <span id="extension-version">-</span></div>


### PR DESCRIPTION
Partial solution until new logo is added.

<img width="311" height="163" alt="image" src="https://github.com/user-attachments/assets/66561c07-b1c7-4f67-923c-ff76f0b85843" />