### PR TITLE
Replace settings back icon and fix styling

### DIFF
--- a/options.html
+++ b/options.html
@@ -11,10 +11,10 @@
 <body class="options">
     <div id="notification" class="hidden"></div>
 
-    <div id="back">
-        <span id="back-link">←</span>
-    </div>
     <div id="options-wrapper">
+        <div id="back">
+            <span id="back-link">×</span>
+        </div>
         <div class="options-sidebar">
             <h1>Settings</h1>
             <nav>

--- a/style.css
+++ b/style.css
@@ -272,27 +272,37 @@ body.options {
     align-items: center;
     justify-content: flex-start;
     text-align: left;
-    padding: 2rem 1rem;
+    padding: 2rem 0;
     margin: 0;
     font-size: 1rem; /* Smaller base font for options */
+    box-sizing: border-box;
+    overflow-x: hidden;
 }
 
 div#back {
     position: absolute;
-    top: 1rem;
-    left: 4rem;
+    top: 0.5rem;
+    right: 2.5rem;
     text-decoration: none;
-    font-size: 5em;
+    font-size: 4em;
+    line-height: 1;
+    z-index: 10;
+    opacity: 0.6;
+    transition: opacity 0.2s ease;
 }
 
 div#back:hover {
     cursor: pointer;
+    opacity: 1;
 }
 
 #options-wrapper {
+    position: relative;
     max-width: 900px;
     height: 80vh;
-    width: 100%;
+    width: calc(100% - 2rem);
+    margin: 0 auto;
+    box-sizing: border-box;
     background: rgba(128, 128, 128, 0.1);
     border-radius: 8px;
     box-shadow: 0 4px 8px rgba(0,0,0,0.1);


### PR DESCRIPTION
Old icon overlaps with settings window on when half width.

<img width="926" height="791" alt="image" src="https://github.com/user-attachments/assets/2d83250f-aeea-4aa9-9713-24e7d12baf6e" />