### PR TITLE
Add escape keyboard navigation to leave settings

### DIFF
--- a/options.js
+++ b/options.js
@@ -352,8 +352,17 @@ document.addEventListener('DOMContentLoaded', () => {
         })
     });
 
+    // Back link navigation
     document.getElementById("back-link").addEventListener("click", () => {
         chrome.tabs.update({ url: "chrome://newtab" });
+    });
+
+    // Navigate back when pressing Escape
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            chrome.tabs.update({ url: "chrome://newtab" });
+        }
     });
 
     let saveBtn = document.getElementById("save");


### PR DESCRIPTION
Add escape key to exit settings. When the user presses escape, it reloads and closes the setting window. 