### PR TITLE
fix: resolve auto-hide visibility and settings loading issues (#60)

### DIFF
--- a/main.js
+++ b/main.js
@@ -312,7 +312,8 @@ if (localStorage.getItem("settings") === null) {
     localStorage.setItem("settings", JSON.stringify(defaultSettings));
 }
 
-const settings = JSON.parse(localStorage.getItem("settings")) || defaultSettings;
+const storedSettings = JSON.parse(localStorage.getItem("settings")) || {};
+const settings = { ...defaultSettings, ...storedSettings };
 
 // Apply custom CSS if provided
 if (settings.customCSS) {
@@ -486,8 +487,8 @@ if (settings.sidebar) {
             customizeBtn.style.opacity = '0';
             customizeBtn.style.pointerEvents = 'none';
         } else {
-            customizeBtn.style.opacity = '1';
-            customizeBtn.style.pointerEvents = 'auto';
+            customizeBtn.style.opacity = '';
+            customizeBtn.style.pointerEvents = '';
         }
         
         // Hide theme toggle when sidebar is on right and expanded
@@ -495,8 +496,8 @@ if (settings.sidebar) {
             themeToggle.style.opacity = '0';
             themeToggle.style.pointerEvents = 'none';
         } else {
-            themeToggle.style.opacity = '1';
-            themeToggle.style.pointerEvents = 'auto';
+            themeToggle.style.opacity = '';
+            themeToggle.style.pointerEvents = '';
         }
     };
     

--- a/style.css
+++ b/style.css
@@ -252,13 +252,17 @@ body {
 
 /* Auto-hide control buttons */
 body.auto-hide .customize,
-body.auto-hide .theme-toggle {
+body.auto-hide .theme-toggle,
+body.auto-hide .photo-credit,
+body.auto-hide .refresh-background {
     opacity: 0;
     pointer-events: none;
 }
 
 body.auto-hide.controls-visible .customize,
-body.auto-hide.controls-visible .theme-toggle {
+body.auto-hide.controls-visible .theme-toggle,
+body.auto-hide.controls-visible .photo-credit,
+body.auto-hide.controls-visible .refresh-background {
     opacity: 1;
     pointer-events: auto;
 }


### PR DESCRIPTION
Description This PR fixes the auto-hide buttons issue by removing inline opacity overrides and ensuring settings merge correctly. Key Changes:

- Merged storedSettings with defaultSettings.
- Replaced inline opacity: 1 with '' in main.js.

Fixes #60